### PR TITLE
Fixed too many tests being ran

### DIFF
--- a/src/MutantRunResultMatcher.ts
+++ b/src/MutantRunResultMatcher.ts
@@ -1,6 +1,5 @@
 import Mutant from './Mutant';
-import {RunResult, Location} from './api/test_runner';
-import {CoverageResult} from './api/test_runner/Coverage';
+import {RunResult, Location, CoverageResult} from './api/test_runner';
 
 export default class MutantRunResultMatcher {
 

--- a/src/MutantRunResultMatcher.ts
+++ b/src/MutantRunResultMatcher.ts
@@ -27,16 +27,34 @@ export default class MutantRunResultMatcher {
 
   private mutantCoversFile(mutant: Mutant, coveredFile: CoverageResult): boolean {
     let smallestStatementFound = "";
-    
+    let smallestStatementLocation: Location;
+
     Object.keys(coveredFile.statementMap).forEach(statementId => {
       let location = coveredFile.statementMap[parseInt(statementId)];
-        
-      if(this.mutantCoversLocation(mutant, location)){
+
+      if (this.mutantCoversLocation(mutant, location) && this.isNewSmallestStatement(smallestStatementLocation, location)) {
         smallestStatementFound = statementId;
+        smallestStatementLocation = location;
       }
     });
 
     return smallestStatementFound.length > 0 && coveredFile.s[smallestStatementFound] !== 0;
+  }
+
+  private isNewSmallestStatement(originalLocation: Location, newLocation: Location): boolean {
+    let statementIsSmallestStatement = false;
+    if (!originalLocation) {
+      statementIsSmallestStatement = true;
+    } else {
+      let lineDifference = (originalLocation.end.line - originalLocation.start.line) - (newLocation.end.line - newLocation.start.line);
+      let coversLessLines = lineDifference > 0;
+      let coversLessColumns = lineDifference === 0 && (newLocation.start.column - originalLocation.start.column) + (originalLocation.end.column - newLocation.end.column) > 0;
+      if (coversLessLines || coversLessColumns) {
+        statementIsSmallestStatement = true;
+      }
+    }
+
+    return statementIsSmallestStatement;
   }
 
   private mutantCoversLocation(mutant: Mutant, location: Location): boolean {

--- a/src/karma-runner/KarmaTestRunner.ts
+++ b/src/karma-runner/KarmaTestRunner.ts
@@ -167,7 +167,7 @@ export default class KarmaTestRunner extends TestRunner {
   }
 
   private static convertTestResult(testResults: karma.TestResults) {
-    if (testResults.error) {
+    if (testResults.error && testResults.failed === 0) {
       return TestResult.Error;
     } else if (testResults.disconnected) {
       return TestResult.Timeout;

--- a/test/unit/MutantRunResultMatcherSpec.ts
+++ b/test/unit/MutantRunResultMatcherSpec.ts
@@ -59,16 +59,16 @@ describe('MutantRunResultMatcher', () => {
               statementMap: {
                 1: {
                   start: { line: 3, column: 0 },
-                  end: { line: 5, column: 5 }
+                  end: { line: 5, column: 10 }
                 },
                 2: {
-                  start: { line: 5, column: 7 },
+                  start: { line: 5, column: 0 },
+                  end: { line: 5, column: 10 }
+                },
+                3: { // Smallest statement that surrounds the mutant. Differs based on column number
+                  start: { line: 5, column: 4 },
                   end: { line: 5, column: 8 }
                 },
-                3: { // covers but not in 's' map
-                  start: { line: 5, column: 0 },
-                  end: { line: 5, column: 8 }
-                }
               },
               s: {
                 1: 1,
@@ -79,12 +79,22 @@ describe('MutantRunResultMatcher', () => {
             5: {
               statementMap: {
                 1: {
+                  start: { line: 0, column: 1 },
+                  end: { line: 10, column: 5 }
+                },
+                2: { // Smallest  statement that surround the mutant. Differs based on line number
+                  start: { line: 9, column: 1 },
+                  end: { line: 10, column: 5 }
+                },
+                3: {
                   start: { line: 10, column: 1 },
                   end: { line: 10, column: 5 }
                 }
               },
-              s: {
-                1: 1
+              s: {  
+                1: 1,
+                2: 0,
+                3: 1
               }
             }
           };


### PR DESCRIPTION
The correct tests are now matched with every Mutant. The MutantRunResultMatcher now looks for the smallest statement that covers a mutant. If this statement does NOT cover the mutant: then the mutant is not covered by this test.

There is an issue with Karma, it reports that a run has caused an error if every test failed. This caused mutants which were covered and killed by one test to be reported as 'untested'. I have solved this issue by checking if no test failed when determining if a run caused an error.